### PR TITLE
Add LinuxBrew HOMEBREW_PREFIX as config search path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -343,14 +343,16 @@ func initConfig() {
 	viper.SetConfigName("kube-config")
 	viper.AddConfigPath(".")
 	viper.AddConfigPath("$HOME/.kube-config") // adding home directory as first search path
+	viper.AddConfigPath(os.Getenv("HOMEBREW_PREFIX") + "/etc")  // linuxbrew sandbox etc directory
 	viper.AddConfigPath("/usr/local/etc")     // homebrew sandbox etc directory
+	viper.AddConfigPath(os.Getenv("HOMEBREW_PREFIX") + "/lib")  // linuxbrew sandbox lib directory
 	viper.AddConfigPath("/usr/local/lib")     // homebrew sandbox lib directory
 	viper.AddConfigPath("/etc")
 	viper.AutomaticEnv() // read in environment variables that match
 
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err == nil {
-		log.Debug("Using config file: ", viper.ConfigFileUsed())
+		log.Info("Using config file: ", viper.ConfigFileUsed())
 	}
 
 	currentUser, err := user.Current()


### PR DESCRIPTION
This should allow LinuxBrew users to leverage the `HOMEBREW_PREFIX` environment variable as a valid search path for kube-config. Negates any need to symlink `/home/linuxbrew/.linuxbrew/lib/kube-config.yml` and allows users to install ancillary kube-config.yml files with `brew` and use them with ease.