### PR TITLE
Add --print-groups/-g option, prints AD groups to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,18 @@ If you want to write your `KUBECONFIG` to a specific directory, use `--output|-o
 `kube-config` flags from the `--help` output:
 
     Flags:
-      -c, --cluster string       Cluster to use as current-context (default is first in config)
-          --debug                Print all request and responses from the OpenID Connect issuer
-      -h, --help                 help for kube-config
-          --list-tiers           If specified, the program will list the available tiers and then exit
-      -n, --namespace string     Set your default namespace across ALL contexts in the tier
-      -k, --no-verify-ssl        If specified, disable SSL cert checking (WARNING: UNSAFE)
-      -o, --output string        Path to write Kubeconfig file (default "/home/lbriggs/.kube/config.d")
-      -t, --tier string          Tier to authenticate for (default "dev")
-          --caservername string  Override Servername used for verifying cluster CA server certificate
-      -u, --username string      Username for login
+        --caservername string   Servername for CA service
+    -c, --cluster string        Cluster to use as current-context (default is first in config)
+        --debug                 Print all request and responses from the OpenID Connect issuer
+    -h, --help                  help for kube-config
+        --list-tiers            If specified, the program will list the available tiers and then exit
+    -n, --namespace string      Set your default namespace across ALL contexts in the tier
+    -k, --no-verify-ssl         If specified, disable SSL cert checking (WARNING: UNSAFE)
+    -o, --output string         Path to write Kubeconfig file (default "/home/lbriggs/.kube/config.d")
+    -g, --print-groups          If specified, will print out the AD groups you belong to
+    -t, --tier string           Tier to authenticate for (default "dev")
+    -u, --username string       Username for login
+
 
 Run kube config with a tier and cluster target:
 

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"crypto/tls"
 	b64 "encoding/base64"
-	"github.com/hashicorp/go-cleanhttp"
 	log "github.com/Sirupsen/logrus"
+	"github.com/hashicorp/go-cleanhttp"
 	"io/ioutil"
 	//"net/http"
 )

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
+	"sort"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	t "github.com/apptio/kube-config/pkg/templates"
 	"github.com/coreos/go-oidc"
-	log "github.com/Sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
 
@@ -115,6 +117,20 @@ func (a *app) handleCallback(w http.ResponseWriter, r *http.Request) {
 	a.kubeconfig.Generate(rawIDToken, token.RefreshToken)
 	a.tokenRetrieved <- 1
 
+	if printgroups {
+		var claimsJSON map[string]interface{}
+		json.Unmarshal(claims, &claimsJSON)
+		groups := claimsJSON["groups"].([]interface{})
+		groupSlice := make([]string, len(groups))
+		for i, group := range groups {
+			groupSlice[i] = group.(string)
+		}
+		sort.Strings(groupSlice)
+		for _, group := range groupSlice {
+			fmt.Println(group)
+		}
+		os.Exit(0)
+	}
 }
 
 func (a *app) handleLogin(w http.ResponseWriter, r *http.Request) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ package cmd
 import (
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/user"
 
@@ -63,6 +64,7 @@ var (
 	tier           string
 	listTiers      bool
 	caservername   string
+	printgroups    bool
 )
 
 // for the version command
@@ -321,6 +323,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&cluster, "cluster", "c", "", "Cluster to use as current-context (default is first in config)")
 	RootCmd.PersistentFlags().StringVarP(&outputFilePath, "output", "o", os.Getenv("HOME")+"/.kube/config.d", "Path to write Kubeconfig file")
 	RootCmd.PersistentFlags().BoolVarP(&insecure, "no-verify-ssl", "k", false, "If specified, disable SSL cert checking (WARNING: UNSAFE)")
+	RootCmd.PersistentFlags().BoolVarP(&printgroups, "print-groups", "g", false, "If specified, will print out the AD groups you belong to")
 	RootCmd.PersistentFlags().BoolVar(&listTiers, "list-tiers", false, "If specified, the program will list the available tiers and then exit")
 	viper.BindPFlag("username", RootCmd.PersistentFlags().Lookup("username"))
 	RootCmd.PersistentFlags().MarkHidden("client-id")
@@ -340,13 +343,17 @@ func initConfig() {
 		log.SetLevel(log.DebugLevel)
 	}
 
+	if printgroups {
+		log.SetOutput(ioutil.Discard)
+	}
+
 	viper.SetConfigName("kube-config")
 	viper.AddConfigPath(".")
-	viper.AddConfigPath("$HOME/.kube-config") // adding home directory as first search path
-	viper.AddConfigPath(os.Getenv("HOMEBREW_PREFIX") + "/etc")  // linuxbrew sandbox etc directory
-	viper.AddConfigPath("/usr/local/etc")     // homebrew sandbox etc directory
-	viper.AddConfigPath(os.Getenv("HOMEBREW_PREFIX") + "/lib")  // linuxbrew sandbox lib directory
-	viper.AddConfigPath("/usr/local/lib")     // homebrew sandbox lib directory
+	viper.AddConfigPath("$HOME/.kube-config")                  // adding home directory as first search path
+	viper.AddConfigPath(os.Getenv("HOMEBREW_PREFIX") + "/etc") // linuxbrew sandbox etc directory
+	viper.AddConfigPath("/usr/local/etc")                      // homebrew sandbox etc directory
+	viper.AddConfigPath(os.Getenv("HOMEBREW_PREFIX") + "/lib") // linuxbrew sandbox lib directory
+	viper.AddConfigPath("/usr/local/lib")                      // homebrew sandbox lib directory
 	viper.AddConfigPath("/etc")
 	viper.AutomaticEnv() // read in environment variables that match
 


### PR DESCRIPTION
This took me a super crazy long amount of time because I didn't yet know how to work with JSON in Go. For all intents and purposes, it works, but I wasn't sure about the location of the code. 

I decided to:

```golang 
	if printgroups {
		log.SetOutput(ioutil.Discard)
	}
```
Because I noticed the normal `log.Info` messages were interleaving with the output. And:
```golang
		os.Exit(0)
```
At the end of the if statement because I didn't think we'd want the program to continue. Though I'm not certain if that's being dirty about the http connection. It seems to close alright. 
